### PR TITLE
add rust-toolchain file

### DIFF
--- a/bouncing-balls/rust-toolchain
+++ b/bouncing-balls/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
Currently this project is dependent on a version of `wbg-rand` that uses an unstable feature. If you try to build this project as is, you'll hit the following error:
```
   Compiling wbg-rand v0.4.1
error[E0554]: #![feature] may not be used on the stable release channel
  --> /[snipped]/.cargo/registry/src/github.com-1ecc6299db9ec823/wbg-rand-0.4.1/src/lib.rs:28:1
   |
28 | #![feature(use_extern_macros)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: aborting due to previous error

For more information about this error, try `rustc --explain E0554`.
```

Simply adding a `rust-toolchain` file in the directory of the project will ensure that users will automatically compile with their version of nightly when building `balls` 